### PR TITLE
fix(event): fix poll expect message

### DIFF
--- a/simple/src/event.rs
+++ b/simple/src/event.rs
@@ -43,7 +43,7 @@ impl EventHandler {
                         .checked_sub(last_tick.elapsed())
                         .unwrap_or(tick_rate);
 
-                    if event::poll(timeout).expect("no events available") {
+                    if event::poll(timeout).expect("Error polling new events") {
                         match event::read().expect("unable to read event") {
                             CrosstermEvent::Key(e) => sender.send(Event::Key(e)),
                             CrosstermEvent::Mouse(e) => sender.send(Event::Mouse(e)),

--- a/simple/src/event.rs
+++ b/simple/src/event.rs
@@ -43,7 +43,7 @@ impl EventHandler {
                         .checked_sub(last_tick.elapsed())
                         .unwrap_or(tick_rate);
 
-                    if event::poll(timeout).expect("Error polling new events") {
+                    if event::poll(timeout).expect("failed to poll new events") {
                         match event::read().expect("unable to read event") {
                             CrosstermEvent::Key(e) => sender.send(Event::Key(e)),
                             CrosstermEvent::Mouse(e) => sender.send(Event::Mouse(e)),


### PR DESCRIPTION
The doc says 

> Returns `Ok(true)` if an [`Event`](https://docs.rs/crossterm/latest/crossterm/event/enum.Event.html) is available otherwise it returns `Ok(false)`.

So "no events available" would correspond to `Ok(false)`.

The doc does not mention the `Err` case but looking at the internal code in `crossterm::event::read.rs`, this is the only place an error is returned.

```rust
        let event_source = match self.source.as_mut() {
            Some(source) => source,
            None => {
                return Err(std::io::Error::new(
                    std::io::ErrorKind::Other,
                    "Failed to initialize input reader",
                ))
            }
        };
```