### PR TITLE
Fix a typo in `README.md`

### DIFF
--- a/component/README.md
+++ b/component/README.md
@@ -8,7 +8,7 @@ You can start by using `cargo-generate`:
 
 ```shell
 cargo install cargo-generate
-cargo generate ratatui-org/templates async --name ratatui-hello-world
+cargo generate ratatui-org/templates component --name ratatui-hello-world
 cd ratatui-hello-world
 ```
 


### PR DESCRIPTION
`async` is not a subfolder in source template. Perhaps what you mean is `component`.