### PR TITLE
Break loop when channel is closed

### DIFF
--- a/simple-async/src/event.rs
+++ b/simple-async/src/event.rs
@@ -44,6 +44,9 @@ impl EventHandler {
                 let tick_delay = tick.tick();
                 let crossterm_event = reader.next().fuse();
                 tokio::select! {
+                  _ = _sender.closed() => {
+                    break;
+                  }
                   _ = tick_delay => {
                     _sender.send(Event::Tick).unwrap();
                   }


### PR DESCRIPTION
When I keep typing on the keyboard and press ESC to exit the program, the program will panic due to channel closure.

![image](https://github.com/ratatui-org/templates/assets/47047883/b2b8a8c8-c823-43e6-be9a-7bfb603fd352)
