### PR TITLE
fix: rename `Action::Refresh` -> `Action::ClearScreen`, add handler, update tui restore logic after suspend

### DIFF
--- a/component/template/src/action.rs
+++ b/component/template/src/action.rs
@@ -14,7 +14,7 @@ pub enum Action {
   Suspend,
   Resume,
   Quit,
-  Refresh,
+  ClearScreen,
   Error(String),
   Help,
 }

--- a/component/template/src/app.rs
+++ b/component/template/src/app.rs
@@ -105,6 +105,7 @@ impl App {
           Action::Quit => self.should_quit = true,
           Action::Suspend => self.should_suspend = true,
           Action::Resume => self.should_suspend = false,
+          Action::ClearScreen => tui.terminal.clear()?,
           Action::Resize(w, h) => {
             tui.resize(Rect::new(0, 0, w, h))?;
             tui.draw(|f| {
@@ -137,7 +138,7 @@ impl App {
       if self.should_suspend {
         tui.suspend()?;
         action_tx.send(Action::Resume)?;
-        tui = tui::Tui::new()?.tick_rate(self.tick_rate).frame_rate(self.frame_rate);
+        action_tx.send(Action::ClearScreen)?;
         // tui.mouse(true);
         tui.enter()?;
       } else if self.should_quit {


### PR DESCRIPTION
## Description

Related thread: https://github.com/ratatui-org/ratatui-website/pull/651#discussion_r1661380107
- Renames `Action::Refresh` to `Action::ClearScreen` since we weren't using it
- Use `terminal.clear()` to restore tui on `Action::ClearScreen`
- Send `Action::ClearScreen` after `Action::Resume` to restore tui without reinitializing tui