### PR TITLE
fix(event-driven): avoid duplicate key event handling on Windows

### DIFF
--- a/event-driven-async-generated/src/app.rs
+++ b/event-driven-async-generated/src/app.rs
@@ -38,7 +38,11 @@ impl App {
             match self.events.next().await? {
                 Event::Tick => self.tick(),
                 Event::Crossterm(event) => match event {
-                    crossterm::event::Event::Key(key_event) => self.handle_key_events(key_event)?,
+                    crossterm::event::Event::Key(key_event)
+                        if key_event.kind == crossterm::event::KeyEventKind::Press =>
+                    {
+                        self.handle_key_events(key_event)?
+                    }
                     _ => {}
                 },
                 Event::App(app_event) => match app_event {

--- a/event-driven-async/template/src/app.rs
+++ b/event-driven-async/template/src/app.rs
@@ -38,7 +38,11 @@ impl App {
             match self.events.next().await? {
                 Event::Tick => self.tick(),
                 Event::Crossterm(event) => match event {
-                    crossterm::event::Event::Key(key_event) => self.handle_key_events(key_event)?,
+                    crossterm::event::Event::Key(key_event)
+                        if key_event.kind == crossterm::event::KeyEventKind::Press =>
+                    {
+                        self.handle_key_events(key_event)?
+                    }
                     _ => {}
                 },
                 Event::App(app_event) => match app_event {

--- a/event-driven-generated/src/app.rs
+++ b/event-driven-generated/src/app.rs
@@ -44,7 +44,11 @@ impl App {
         match self.events.next()? {
             Event::Tick => self.tick(),
             Event::Crossterm(event) => match event {
-                crossterm::event::Event::Key(key_event) => self.handle_key_event(key_event)?,
+                crossterm::event::Event::Key(key_event)
+                    if key_event.kind == crossterm::event::KeyEventKind::Press =>
+                {
+                    self.handle_key_event(key_event)?
+                }
                 _ => {}
             },
             Event::App(app_event) => match app_event {

--- a/event-driven/template/src/app.rs
+++ b/event-driven/template/src/app.rs
@@ -44,7 +44,11 @@ impl App {
         match self.events.next()? {
             Event::Tick => self.tick(),
             Event::Crossterm(event) => match event {
-                crossterm::event::Event::Key(key_event) => self.handle_key_event(key_event)?,
+                crossterm::event::Event::Key(key_event)
+                    if key_event.kind == crossterm::event::KeyEventKind::Press =>
+                {
+                    self.handle_key_event(key_event)?
+                }
                 _ => {}
             },
             Event::App(app_event) => match app_event {


### PR DESCRIPTION
Fixes [#116](https://github.com/ratatui/templates/issues/116): Filters out non-`Press` key events from Crossterm to prevent duplicate handling on Windows. This ensures consistent behavior across platforms in event-driven templates.
