### PR TITLE
docs: use full path for color_eyre::Result

### DIFF
--- a/component-generated/src/components.rs
+++ b/component-generated/src/components.rs
@@ -23,7 +23,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<()>` - An Ok result or an error.
+    /// * [`color_eyre::Result<()>`] - An Ok result or an error.
     fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> color_eyre::Result<()> {
         let _ = tx; // to appease clippy
         Ok(())
@@ -36,7 +36,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<()>` - An Ok result or an error.
+    /// * [`color_eyre::Result<()>`] - An Ok result or an error.
     fn register_config_handler(&mut self, config: Config) -> color_eyre::Result<()> {
         let _ = config; // to appease clippy
         Ok(())
@@ -49,7 +49,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<()>` - An Ok result or an error.
+    /// * [`color_eyre::Result<()>`] - An Ok result or an error.
     fn init(&mut self, area: Size) -> color_eyre::Result<()> {
         let _ = area; // to appease clippy
         Ok(())
@@ -62,7 +62,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<Option<Action>>` - An action to be processed or none.
+    /// * [`color_eyre::Result<Option<Action>>`] - An action to be processed or none.
     fn handle_events(&mut self, event: Option<Event>) -> color_eyre::Result<Option<Action>> {
         let action = match event {
             Some(Event::Key(key_event)) => self.handle_key_event(key_event)?,
@@ -79,7 +79,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<Option<Action>>` - An action to be processed or none.
+    /// * [`color_eyre::Result<Option<Action>>`] - An action to be processed or none.
     fn handle_key_event(&mut self, key: KeyEvent) -> color_eyre::Result<Option<Action>> {
         let _ = key; // to appease clippy
         Ok(None)
@@ -92,7 +92,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<Option<Action>>` - An action to be processed or none.
+    /// * [`color_eyre::Result<Option<Action>>`] - An action to be processed or none.
     fn handle_mouse_event(&mut self, mouse: MouseEvent) -> color_eyre::Result<Option<Action>> {
         let _ = mouse; // to appease clippy
         Ok(None)
@@ -105,7 +105,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<Option<Action>>` - An action to be processed or none.
+    /// * [`color_eyre::Result<Option<Action>>`] - An action to be processed or none.
     fn update(&mut self, action: Action) -> color_eyre::Result<Option<Action>> {
         let _ = action; // to appease clippy
         Ok(None)
@@ -119,6 +119,6 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<()>` - An Ok result or an error.
+    /// * [`color_eyre::Result<()>`] - An Ok result or an error.
     fn draw(&mut self, frame: &mut Frame, area: Rect) -> color_eyre::Result<()>;
 }

--- a/component-generated/src/config.rs
+++ b/component-generated/src/config.rs
@@ -6,7 +6,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use directories::ProjectDirs;
 use lazy_static::lazy_static;
 use ratatui::style::{Color, Modifier, Style};
-use serde::{Deserialize, de::Deserializer};
+use serde::{de::Deserializer, Deserialize};
 use tracing::error;
 
 use crate::{action::Action, app::Mode};

--- a/component/template/src/components.rs
+++ b/component/template/src/components.rs
@@ -23,7 +23,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<()>` - An Ok result or an error.
+    /// * [`color_eyre::Result<()>`] - An Ok result or an error.
     fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> color_eyre::Result<()> {
         let _ = tx; // to appease clippy
         Ok(())
@@ -36,7 +36,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<()>` - An Ok result or an error.
+    /// * [`color_eyre::Result<()>`] - An Ok result or an error.
     fn register_config_handler(&mut self, config: Config) -> color_eyre::Result<()> {
         let _ = config; // to appease clippy
         Ok(())
@@ -49,7 +49,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<()>` - An Ok result or an error.
+    /// * [`color_eyre::Result<()>`] - An Ok result or an error.
     fn init(&mut self, area: Size) -> color_eyre::Result<()> {
         let _ = area; // to appease clippy
         Ok(())
@@ -62,7 +62,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<Option<Action>>` - An action to be processed or none.
+    /// * [`color_eyre::Result<Option<Action>>`] - An action to be processed or none.
     fn handle_events(&mut self, event: Option<Event>) -> color_eyre::Result<Option<Action>> {
         let action = match event {
             Some(Event::Key(key_event)) => self.handle_key_event(key_event)?,
@@ -79,7 +79,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<Option<Action>>` - An action to be processed or none.
+    /// * [`color_eyre::Result<Option<Action>>`] - An action to be processed or none.
     fn handle_key_event(&mut self, key: KeyEvent) -> color_eyre::Result<Option<Action>> {
         let _ = key; // to appease clippy
         Ok(None)
@@ -92,7 +92,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<Option<Action>>` - An action to be processed or none.
+    /// * [`color_eyre::Result<Option<Action>>`] - An action to be processed or none.
     fn handle_mouse_event(&mut self, mouse: MouseEvent) -> color_eyre::Result<Option<Action>> {
         let _ = mouse; // to appease clippy
         Ok(None)
@@ -105,7 +105,7 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<Option<Action>>` - An action to be processed or none.
+    /// * [`color_eyre::Result<Option<Action>>`] - An action to be processed or none.
     fn update(&mut self, action: Action) -> color_eyre::Result<Option<Action>> {
         let _ = action; // to appease clippy
         Ok(None)
@@ -119,6 +119,6 @@ pub trait Component {
     ///
     /// # Returns
     ///
-    /// * `Result<()>` - An Ok result or an error.
+    /// * [`color_eyre::Result<()>`] - An Ok result or an error.
     fn draw(&mut self, frame: &mut Frame, area: Rect) -> color_eyre::Result<()>;
 }


### PR DESCRIPTION
Follow up to [this](https://github.com/ratatui/templates/pull/121#discussion_r2573551491)

To create the correct link, rustdoc seems to need the full path to `color_eyre::Result` or it uses the one from std.