### PR TITLE
Fix components template not handling Action::Error

### DIFF
--- a/component-generated/src/app.rs
+++ b/component-generated/src/app.rs
@@ -144,6 +144,9 @@ impl App {
                 Action::ClearScreen => tui.terminal.clear()?,
                 Action::Resize(w, h) => self.handle_resize(tui, w, h)?,
                 Action::Render => self.render(tui)?,
+                Action::Error(ref err) => {
+                    tracing::error!(?err)
+                }
                 _ => {}
             }
             for component in self.components.iter_mut() {

--- a/component/template/src/app.rs
+++ b/component/template/src/app.rs
@@ -144,6 +144,9 @@ impl App {
                 Action::ClearScreen => tui.terminal.clear()?,
                 Action::Resize(w, h) => self.handle_resize(tui, w, h)?,
                 Action::Render => self.render(tui)?,
+                Action::Error(ref err) => {
+                    tracing::error!(?err)
+                }
                 _ => {}
             }
             for component in self.components.iter_mut() {


### PR DESCRIPTION

Fixes #135 

Action::Error is used
https://github.com/ratatui/templates/blob/cd2b97b11fd4dcc40607e8ab3f73bc09c12c6a4f/component/template/src/app.rs#L164-L175

but never handled. This handles it simply with tracing::error!
